### PR TITLE
add swagger ui support for a list of examples

### DIFF
--- a/fastapi/openapi/utils.py
+++ b/fastapi/openapi/utils.py
@@ -166,6 +166,12 @@ def get_openapi_operation_request_body(
         examples = {k: v for k, v in examples.items() if "value" in v}
         body_schema["examples"] = [dct["value"] for dct in examples.values()]
         request_media_content["examples"] = examples
+    
+    elif isinstance(examples, list):
+        body_schema["examples"] = examples
+        request_media_content["examples"] = {}
+        for n, item in enumerate(examples):
+            request_media_content["examples"][f"example {n + 1}"] = {"value": item}
 
     request_media_content["schema"] = body_schema
     if field_info.example != Undefined:


### PR DESCRIPTION
I've added support to generate a dropdown when passing in a list of examples, it generates a name dynamically based on the list index of each example. You can test with the following code, it contains a list of examples and a dictionary of examples, you can swap the variables supplied to the body to test that both work.

```
from pydantic import BaseModel
from typing import Union
from fastapi import Body, FastAPI


class Item(BaseModel):
    name: str
    description: Union[str, None] = None
    price: float
    tax: Union[float, None] = None


named_examples = {
    "normal": {
        "summary": "A normal example",
        "description": "A **normal** item works correctly.",
        "value": {
            "name": "Foo",
            "description": "A very nice Item",
            "price": 35.4,
            "tax": 3.2,
        },
    },
    "converted": {
        "summary": "An example with converted data",
        "description": "FastAPI can convert price `strings` to actual `numbers` automatically",
        "value": {
            "name": "Bar",
            "price": "35.4",
        },
    },
    "invalid": {
        "summary": "Invalid data is rejected with an error",
        "value": {
            "name": "Baz",
            "price": "thirty five point four",
        },
    },
}


list_examples = [
    {
        "name": "Foo",
        "description": "A very nice Item!",
        "price": 35.4,
        "tax": 3.2,
    },
    {
        "name": "Bar",
        "price": "35.4",
    },
    {
        "name": "Baz",
        "price": "thirty five point four",
    },
]

#
# app
#

app = FastAPI()

@app.post("/items")
async def post_item(item: Item = Body(examples=named_examples)) -> Item:
    return item
```